### PR TITLE
fix: fix mcp stdio code

### DIFF
--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -93,10 +93,11 @@
     "%pip install -q 'volcengine-python-sdk[ark]'\n",
     "\n",
     "# for agent demos\n",
-    "%pip install -q arkitect==0.2.2 --index-url https://pypi.org/simple\n",
+    "%pip install -q arkitect==0.2.3 --index-url https://pypi.org/simple\n",
     "\n",
     "# for mcp-related demos\n",
     "%pip install -q fastmcp\n",
+    "%pip install -q mcp_server_time\n",
     "\n",
     "# for RAG-related demos\n",
     "%pip install -q chromadb\n",
@@ -909,11 +910,7 @@
    "id": "a8b11f5e",
    "metadata": {},
    "source": [
-    "#### Stdio mode\n",
-    "\n",
-    "No backend service needed.\n",
-    "\n",
-    "**NOTE** Currently, the stdio mode is not supported in notebook environment, you can execute the code on your local.  "
+    "#### Stdio mode"
    ]
   },
   {
@@ -935,11 +932,16 @@
    "id": "075faba4",
    "metadata": {},
    "source": [
-    "**MCP Client**\n",
-    "\n",
-    "Run the following code on your local.\n",
-    "\n",
-    "```python\n",
+    "**MCP Client**\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1b0af3a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from arkitect.core.component.context.context import Context\n",
     "from arkitect.core.component.tool.mcp_client import MCPClient\n",
     "\n",
@@ -950,6 +952,7 @@
     "    name=\"TimeTools\",\n",
     "    command=\"python\",\n",
     "    arguments=[\"-m\", \"mcp_server_time\", \"--local-timezone\", \"Asia/Shanghai\"],\n",
+    "    errlog=None,        # This item needs to be set in Colab, but it is not required for local running.\n",
     ")\n",
     "\n",
     "#\n",
@@ -975,8 +978,7 @@
     "#\n",
     "# Clean up async resources (best practice)\n",
     "#\n",
-    "await mcp_client.cleanup()\n",
-    "```"
+    "await mcp_client.cleanup()"
    ]
   },
   {
@@ -1965,7 +1967,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "arkintelligence",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -1979,7 +1981,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.11.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary by Sourcery

Update the tutorial notebook to fix stdio mode examples and refresh related dependencies and metadata.

Enhancements:
- Bump arkitect dependency to version 0.2.3 in installation instructions
- Include installation of mcp_server_time alongside fastmcp for MCP demos
- Simplify the stdio mode section and embed the MCP Client example in a proper code cell
- Add an errlog parameter note for local MCP Client execution
- Update notebook metadata with new kernel display name and Python version